### PR TITLE
メンバーの変更・異動に合わせてHPの内容を更新しました。

### DIFF
--- a/docs/people.html
+++ b/docs/people.html
@@ -93,7 +93,7 @@
         <div id="con_bg">
             <div id="con">
 
-                <div id="main">
+                <e id="main">
                     <main>
                         <article>
 
@@ -246,7 +246,7 @@ chiemi[at]slis.tsukuba.ac.jp
                                     </div>
                                      /-->
                                     <!--people_list end-->
-                                    
+
                             <div class="people_list">
                                         <div class="people_list_text">
                                             <div class="people_list_title">名合 洋子 / スタッフ<span>Yoko Nago / Laboratory Staff</span></div>
@@ -266,11 +266,11 @@ chiemi[at]slis.tsukuba.ac.jp
                                 <h2>GRADUATE STUDENTS</h2>
 
 
-                            <h3>D3</h3>
+                            <!-- <h3>D3</h3>
                             <div class="people_list_box">
                                 <div class="people_list">
                                 </div>
-                            </div>
+                            </div> -->
                             <!--people_list end-->
 
 
@@ -299,7 +299,7 @@ chiemi[at]slis.tsukuba.ac.jp
                                         <span class="people_list_icon">リンク</span>
                                         <a href="https://kousukeuo.github.io/">Personal page</a>
                                     </div>
-                                </div>
+                                </div>-->
                                 <!--people_list end-->
 
 
@@ -311,7 +311,7 @@ chiemi[at]slis.tsukuba.ac.jp
                                         <a href="http://www.u.tsukuba.ac.jp/~s1411569/mlab_furuhashi">Personal page</a>
                                     </div>
                                 </div>
-                                
+
                                  <div class="people_list">
                                     <div class="people_list_text">
                                         <div class="people_list_title">中山 拓海 / Nakayama Takumi</div>
@@ -338,7 +338,7 @@ chiemi[at]slis.tsukuba.ac.jp
                                         <a href="https://itsukimurayama.github.io">Personal page</a>
                                     </div>
                                 </div>
-                                
+
                                 <div class="people_list">
                                     <div class="people_list_text">
                                         <div class="people_list_title">津本　紗希 / Tsumoto Saki</div>
@@ -347,7 +347,7 @@ chiemi[at]slis.tsukuba.ac.jp
                                         <a href="https://tsumotosaki.github.io/">Personal page</a>
                                     </div>
                                 </div>
-                                
+
                                 <!--people_list end-->
 
                                 <!--people_list end-->
@@ -366,7 +366,7 @@ chiemi[at]slis.tsukuba.ac.jp
                                         <a href="https://naofumi1014.github.io/">Personal page</a>
                                     </div>
                                 </div>
-                                
+
                                 <div class="people_list">
                                     <div class="people_list_text">
                                         <div class="people_list_title">渡邉 真悟 / Shingo Watanabe</div>
@@ -383,7 +383,7 @@ chiemi[at]slis.tsukuba.ac.jp
                                         <a href="https://neginex.github.io/Nexicon/">Personal page</a>
                                     </div>
                                 </div>
-                                
+
                                 <div class="people_list">
                                     <div class="people_list_text">
                                         <div class="people_list_title">木田　開 / Kai Kida</div>
@@ -392,10 +392,19 @@ chiemi[at]slis.tsukuba.ac.jp
                                         <a href="https://nove0316.github.io/mypage/">Personal page</a>
                                     </div>
                                 </div>
-                                
-                            </div>    
-                                
-                                
+
+                                <div class="people_list">
+                                    <div class="people_list_text">
+                                        <div class="people_list_title">神田翔 / Sho Kanda</div>
+                                        <p></p>
+                                        <span class="people_list_icon">リンク</span>
+                                        <a href="https://kan-chance.github.io">Personal page</a>
+                                    </div>
+                                </div>
+
+                            </div>
+
+
                             <!--people_list end-->
                             <section id="under">
                                 <h2>UNDERGRADUATES</h2>
@@ -412,23 +421,6 @@ chiemi[at]slis.tsukuba.ac.jp
                                             <a href="https://yu1003.github.io/mlab-profile/">Personal page</a>
                                         </div>
                                     </div>
-                                   
-
-                                    <div class="people_list">
-                                        <div class="people_list_text">
-                                            <div class="people_list_title">神田翔 / Sho Kanda</div>
-                                            <p></p>
-                                            <span class="people_list_icon">リンク</span>
-                                            <a href="https://kan-chance.github.io">Personal page</a>
-                                        </div>
-                                    </div>
-
-                                </div>
-                                <!--people_list end-->
-
-                                <h3>B3</h3>
-
-                                <div class="people_list_box">
 
                                     <div class="people_list">
                                         <div class="people_list_text">
@@ -481,7 +473,7 @@ chiemi[at]slis.tsukuba.ac.jp
                                 </div>
                                 <!--people_list end-->
 
-                                </div>
+                            </section>
                 </div>
 
             </div>


### PR DESCRIPTION
D3がいないので非表示にしました。
神田翔さんをM1に、山下さんをB4に、B3生全員をB4にしました。
ブラウザで表示した際の見た目は以下のようになります。
![screencapture-file-Users-macbookpro-github-fusioncomplab-docs-people-html-2022-05-09-23_46_00](https://user-images.githubusercontent.com/64148935/167435989-d3c8bc3b-7c09-41c0-942d-947a446caa37.png)
