### PR TITLE
卒業に関連する変更

### DIFF
--- a/docs/people.html
+++ b/docs/people.html
@@ -351,14 +351,6 @@ chiemi[at]slis.tsukuba.ac.jp
                                     </div>
                                 </div>
                                 <div class="people_list">
-                                    <div class="people_list_text">
-                                        <div class="people_list_title">小泉 崇裕 / Takahiro Koizumi</div>
-                                        <p></p>
-                                        <span class="people_list_icon">リンク</span>
-                                        <a href="https://www.folklore.place/portfolio/">Personal page</a>
-                                    </div>
-                                </div>
-                                <div class="people_list">
                                         <div class="people_list_text">
                                             <div class="people_list_title">神田　智也 / Tomoya Kanda</div>
                                             <p></p>

--- a/docs/people/alumni.html
+++ b/docs/people/alumni.html
@@ -46,7 +46,7 @@
                         <li><a href="../index.html" class="current">HOME<span>ホーム</a></li>
                         <li><a href="../vision.html">VISION<span>ビジョン</a></li>
                         <li><a href="../people.html">PEOPLE<span>メンバー</a></li>
-                        <li><a href="../forb3.html">For B3<span>B3生へ</a></li>
+                        <li><a href="../forb3.html">JOINING LAB<span>参加してみよう！</span></a></li>
                         <li><a href="../projects.html">PROJECTS<span>プロジェクト</a></li>
                         <li><a href="../publications.html">PUBLICATIONS<span>研究業績</a></li>
                         <li><a href="../news.html">NEWS<span>ニュース</a></li>
@@ -66,7 +66,7 @@
                 <ul>
                     <li><a href="../vision.html">VISION<span>ビジョン</a></li>
                     <li><a href="../people.html">PEOPLE<span>メンバー</a></li>
-                    <li><a href="../forb3.html">ForB3<span>B3生へ</a></li>
+                    <li><a href="../forb3.html">JOINING LAB<span>参加してみよう！</span></a></li>
                     <li><a href="../projects.html">PROJECTS<span>プロジェクト</a></li>
                     <li><a href="../publications.html">PUBLICATIONS<span>研究業績</a></li>
                     <li><a href="../news.html">NEWS<span>ニュース</a></li>

--- a/docs/people/alumni.html
+++ b/docs/people/alumni.html
@@ -103,6 +103,7 @@
                                 <nav>
                                     <ul>
                                         <li></li>
+                                        <li><a href="#2024">2024</a></li>
                                         <li><a href="#2023">2023</a></li>
                                         <li><a href="#2022">2022</a></li>
 					                    <li><a href="#2021">2021</a></li>
@@ -143,6 +144,15 @@
 
 </div>
 -->
+                <h3>2024年度</h3>
+                <div class="people_list_box" id="2024">
+                    <div class="people_list">
+                        <div class="people_list_text">
+                            <div class="people_list_title">小泉 崇裕 / Takahiro Koizumi / Master</div>
+                        </div>
+                    </div>
+                </div>
+
                                 <h3>2023年度</h3>
                                 <div class="people_list_box" id="2023">
 				<div class="people_list">

--- a/docs/publications.html
+++ b/docs/publications.html
@@ -250,7 +250,7 @@
                        Hiroyoshi Ito, Takahiro Koizumi, Ryuji Yoshimoto, Yukihiro Fukushima, Takashi Harada, Atsuyuki Morishima,
                        "Inconsistency-driven Approach for Human-in-the-loop Entity Matching",
                        Living in AI-gorithmic world: 20th International Conference, iConference 2025,
-                       pp.###-###.
+                       pp.1024-1038.
                        Virtual Academic Program: March 11-14, 2025,
                        Onsite Academic Program in Indiana Bloomington, USA: March 18-22, 2025,
                      </li>
@@ -842,6 +842,9 @@
                 <h2>国内発表<span>Domestic Conference</span></h2>
                 <div class="publications_list">
                   <ul>
+                    <li>小泉 崇裕, 伊藤 寛祥, 吉本 龍司, 福島 幸宏, 原田 隆史, 森嶋 厚行,「Entity Resolutionにおける同値クラスタを用いたブロッキング手法」,
+                      第17回データ工学と情報マネジメントに関するフォーラム (DEIM2025), 4C-03, オンライン＆福岡国際会議場, 2025年2月27日, 3月4日
+                    </li>
 
                     <li>京谷 辰哉, 伊藤 寛祥, 森嶋 厚行,「機械学習のためのアクティブ・データプール拡張手法」,
                     第16回データ工学と情報マネジメントに関するフォーラム (DEIM2024), T1-A-2-03, オンライン＆アクリエひめじ, 2024年2月28日, 3月4日


### PR DESCRIPTION
以下を修正・加筆
- メンバー紹介の M2 の項目から小泉の名前を削除
- 2024年度卒業生の欄と小泉の名前を追加
- 卒業生のページのナビゲーションバーを他のページで利用している内容に合わせるため修正
- iConference の proceeding 更新